### PR TITLE
[Bug] Render all experience when using --template full

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 .#*
 dist/
+.idea/
+cv.html

--- a/main.go
+++ b/main.go
@@ -84,8 +84,8 @@ func main() {
 
 	case "full":
 		for i, _ := range in.Experience {
-			in.Experience[i].showShort = true
 			in.Experience[i].showMore = true
+			in.Experience[i].showShort = true
 		}
 
 	default:

--- a/templates.go
+++ b/templates.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"fmt"
-	"strings"
-	"time"
-
 	. "github.com/gregoryv/web"
 	"github.com/gregoryv/web/theme"
+	"strings"
+	"time"
 )
 
 func NewCVPage(co *Company, in *CV) *Page {
@@ -80,15 +79,18 @@ func NewCVPage(co *Company, in *CV) *Page {
 			func() *Element {
 
 				s := Section()
-				// find start of oneliners
-				var split int
-				for i, p := range in.Experience {
-					split = i
-					if p.oneLiner {
-						break
+				//Find all one-liners and full-experience
+				var fullExperience []Project
+				var oneLiners []Project
+
+				for _, p := range in.Experience {
+					if p.showMore {
+						fullExperience = append(fullExperience, p)
+					} else if p.showShort {
+						oneLiners = append(oneLiners, p)
 					}
 				}
-				for _, p := range in.Experience[:split] {
+				for _, p := range fullExperience {
 					if p.hide {
 						continue
 					}
@@ -124,8 +126,11 @@ func NewCVPage(co *Company, in *CV) *Page {
 					)
 				}
 
+				if len(oneLiners) == 0 {
+					return s
+				}
 				rest := Section(Class("rest"))
-				for _, p := range in.Experience[split:] {
+				for _, p := range oneLiners {
 					if p.hide {
 						continue
 					}


### PR DESCRIPTION
Previously when using --template full, we ignored the last experience and rendered it out as a one-liner.
As can be seen at https://vallett.se/files/cv.html, which was created with the following parameters `./cv -cv jesper_cv.yaml -co company.yaml -t full` 
The last experience is rendered as a oneliner, when the .yaml config looked like this:
<img width="540" alt="image" src="https://user-images.githubusercontent.com/17760977/161385281-9caf81a5-8e6c-4c28-a929-49f953ae0d2e.png">


This PR resolves this by taking consideration to what type of template we are rendering in `templates.go`.

When rendering the full template type we ignore the finishing oneliner, we also calculate the split by the length of the Experience array, to make sure we don't get an off-by-one error.